### PR TITLE
Refactor: Use Supabase Storage for User Profile Pictures - #28

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-04-08T15:30:48.001114700Z">
+        <DropdownSelection timestamp="2025-04-11T20:58:11.923728300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Sujesh Lakhan\.android\avd\Pixel_9_API_32.avd" />

--- a/app/src/main/java/com/fakebook/SocialMediaApp/CreateUserProfileActivity.kt
+++ b/app/src/main/java/com/fakebook/SocialMediaApp/CreateUserProfileActivity.kt
@@ -1,11 +1,13 @@
 package com.fakebook.SocialMediaApp
 
+import android.Manifest
+import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
-import android.util.Base64
+import android.provider.MediaStore
 import android.util.Log
 import android.widget.Button
 import android.widget.EditText
@@ -14,13 +16,21 @@ import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.graphics.scale
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import com.fakebook.SocialMediaApp.DataModels.User
 import com.fakebook.SocialMediaApp.databinding.ActivityCreateUserProfileBinding
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.FirebaseFirestore
+import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.storage.Storage
+import io.github.jan.supabase.storage.storage
+import io.ktor.http.ContentType
+import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
 
 class CreateUserProfileActivity : AppCompatActivity() {
@@ -42,31 +52,25 @@ class CreateUserProfileActivity : AppCompatActivity() {
     // Firebase FireStore
     private lateinit var firestore: FirebaseFirestore
 
-    // Image URI for the selected profile picture
-    private var base64Image: String = ""
+    // Image for the selected profile picture
+    private var image: ByteArray = ByteArray(0)
 
     // Current user
     private var currentUser: FirebaseUser? = null
 
-    // Activity result launcher for selecting an image from the gallery
-    private val pickImageLauncher =
-        registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-            // If the user selects an image, update the ImageView
-            uri?.let {
-                ivProfilePicture.setImageURI(it)  // Display the selected image
+    // region Supabase Credentials
+    private val supabaseUrl = "https://tegyzsstiwjrixqifddn.supabase.co"
+    private val supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRlZ3l6c3N0aXdqcml4cWlmZGRuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDQwMDY2ODksImV4cCI6MjA1OTU4MjY4OX0.YvSCHiD2ZlcedWuOBy37CJWR-BXEHXTYKWSEfOTwRBw"
+    //endregion
 
-                // Convert the image URI to a Base64 string
-                val convertedImage = uriToBase64(it)
-
-                if (convertedImage != null) {
-                    base64Image = convertedImage // Update the base64Image variable
-                } else {
-                    Toast.makeText(this, "Error processing image", Toast.LENGTH_SHORT).show()
-
-                    Log.e("CreateUserProfileActivity", "Image conversion failed")
-                }
-            }
-        }
+    // Supabase client
+    private val supabase = createSupabaseClient(
+        supabaseUrl = supabaseUrl,
+        supabaseKey = supabaseKey
+    ) {
+        install(Postgrest)
+        install(Storage)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,6 +78,8 @@ class CreateUserProfileActivity : AppCompatActivity() {
 
         // Initialize View Binding
         binding = ActivityCreateUserProfileBinding.inflate(layoutInflater)
+
+        setContentView(binding.root)
 
         // Initialize view components
         ivProfilePicture = binding.ivProfilePic
@@ -102,7 +108,30 @@ class CreateUserProfileActivity : AppCompatActivity() {
         }
 
         btnAddProfilePicture.setOnClickListener {
-            pickImageFromGallery() // Open the gallery to select an image
+            MaterialAlertDialogBuilder(this)
+                .setTitle("Image Source")
+                .setMessage("Choose image from")
+                .setPositiveButtonIcon(ContextCompat.getDrawable(this, R.drawable.ic_camera))
+                .setPositiveButton("Camera") { _, _ ->
+
+                    // Request camera permission
+                    if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)
+                    {
+                        // Permission already granted—launch camera
+                        pickImageFromCamera()
+                    }
+                    else
+                    {
+                        // Request the CAMERA permission at runtime.
+                        requestCameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+                    }
+                }
+                .setNegativeButtonIcon(ContextCompat.getDrawable(this, R.drawable.ic_gallery))
+                .setNegativeButton("Gallery") { _, _ ->
+
+                    pickImageFromGallery()
+                }
+                .show()
         }
 
 
@@ -114,57 +143,73 @@ class CreateUserProfileActivity : AppCompatActivity() {
             val bio = etBio.text.toString().trim()
 
             // Check if all fields are filled
-            if (fullName.isNotEmpty() && username.isNotEmpty() && bio.isNotEmpty() && base64Image.isNotBlank()) {
+            if (fullName.isNotEmpty() && username.isNotEmpty() && bio.isNotEmpty() && image.isNotEmpty()) {
                 // create user in Firebase Authentication
                 registerUser(email, password) { user ->
                     if (user != null) {
                         currentUser = user
 
-                        // create a user object
-                        val newUser = User(
-                            userId = currentUser!!.uid,
-                            email = currentUser!!.email ?: "",
-                            username = username,
-                            fullName = fullName,
-                            bio = bio,
-                            base64ProfilePicture = base64Image
-                        )
+                        // get the users id
+                        val userId = currentUser!!.uid
 
-                        // add user to Firebase FireStore
-                        firestore.collection("users").document(newUser.userId).set(newUser)
+                        // get the users email
+                        val userEmail = currentUser!!.email
 
-                            .addOnSuccessListener {
+                        lifecycleScope.launch {
 
-                                // display toast
-                                Toast.makeText(
-                                    this,
-                                    "Profile Created Successfully",
-                                    Toast.LENGTH_SHORT
-                                ).show()
+                            val imageUrl = uploadImageToStorage(userId)
 
-                                // navigate to main activity
-                                val intent = Intent(this, MainActivity::class.java)
-                                startActivity(intent)
-                                finish()
-                            }
-
-                            .addOnFailureListener { e ->
-                                // log the error
-                                Log.e(
-                                    "CreateUserProfileActivity",
-                                    "Error adding user to FireStore",
-                                    e
+                            // check if link is not empty
+                            if (imageUrl.isNotBlank())
+                            {
+                                // create a user object
+                                val newUser = User(
+                                    userId = userId,
+                                    email = userEmail ?: "",
+                                    username = username,
+                                    fullName = fullName,
+                                    bio = bio,
+                                    profilePictureLink = imageUrl
                                 )
 
-                                // display toast
-                                Toast.makeText(this, "Error Saving Profile", Toast.LENGTH_SHORT)
-                                    .show()
+                                // add user to Firebase FireStore
+                                firestore.collection("users").document(newUser.userId).set(newUser)
 
-                                // navigate back to userEmailPasswordActivity
-                                val intent = Intent(this, UserEmailPasswordActivity::class.java)
-                                startActivity(intent)
-                                finish()
+                                    .addOnSuccessListener {
+
+                                        // display toast
+                                        Toast.makeText(
+                                            this@CreateUserProfileActivity,
+                                            "Profile Created Successfully",
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+
+                                        // navigate to main activity
+                                        val intent = Intent(this@CreateUserProfileActivity, MainActivity::class.java)
+                                        startActivity(intent)
+                                        finish()
+                                    }
+
+                                    .addOnFailureListener { e ->
+                                        // log the error
+                                        Log.e(
+                                            "CreateUserProfileActivity",
+                                            "Error adding user to FireStore",
+                                            e
+                                        )
+
+                                        // display toast
+                                        Toast.makeText(this@CreateUserProfileActivity, "Error Saving Profile", Toast.LENGTH_SHORT)
+                                            .show()
+
+                                        // navigate back to userEmailPasswordActivity
+                                        val intent = Intent(this@CreateUserProfileActivity, UserEmailPasswordActivity::class.java)
+                                        startActivity(intent)
+                                        finish()
+                                    }
                             }
+                        }
+
                     }
                 }
             } else {
@@ -173,11 +218,6 @@ class CreateUserProfileActivity : AppCompatActivity() {
             }
         }
 
-    }
-
-    // Function to open the gallery and let the user pick an image
-    private fun pickImageFromGallery() {
-        pickImageLauncher.launch("image/*")  // Opens the gallery to pick an image
     }
 
     private fun registerUser(email: String, password: String, callback: (FirebaseUser?) -> Unit) {
@@ -223,35 +263,162 @@ class CreateUserProfileActivity : AppCompatActivity() {
             }
     }
 
-    // Function to resize the image to a maximum size
-    private fun resizeBitmap(bitmap: Bitmap): Bitmap {
-        val width = bitmap.width
-        val height = bitmap.height
-        val scale = 500.toFloat() / maxOf(width, height)
+    // region Supabase Methods
 
-        // Bitmap.createScaledBitmap(bitmap, (width * scale).toInt(), (height * scale).toInt(), true)
+    // Upload image to Supabase Storage and return the public URL
+    private suspend fun uploadImageToStorage(userId: String): String
+    {
+        try
+        {
+            // check if post ID is not empty and image is not empty
+            if (userId.isNotEmpty() && image.isNotEmpty())
+            {
+                // Initialize the storage bucket
+                val bucket = supabase.storage.from("banterbox-user-profiles")
 
-        return bitmap.scale((width * scale).toInt(), (height * scale).toInt())
-    }
+                // Upload the image to the specified file path within the bucket
+                bucket.upload(userId, image)
+                {
+                    upsert = false // Set to true to overwrite if the file already exists
+                    contentType = ContentType.Image.JPEG // Set the content type to JPEG
+                }
 
-    // Function to convert image URI to Base64 string
-    private fun uriToBase64(uri: Uri): String? {
-        return try {
-            contentResolver.openInputStream(uri)?.use { inputStream ->
-
-                val originalBitmap = BitmapFactory.decodeStream(inputStream)
-                val resizedBitmap = resizeBitmap(originalBitmap)
-
-                val byteArrayOutputStream = ByteArrayOutputStream()
-                resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 80, byteArrayOutputStream)
-
-                val byteArray = byteArrayOutputStream.toByteArray()
-                Base64.encodeToString(byteArray, Base64.DEFAULT)
+                // Retrieve and return the public URL of the uploaded image
+                return bucket.publicUrl(userId)
             }
-        } catch (e: Exception) {
-            Log.e("CreateUserProfileActivity", "Error converting image to Base64", e)
-            null
+            else
+            {
+                // log the error
+                Log.e("CreatePostActivity", "User ID or image is empty")
+                return ""
+            }
+        } catch (e: Exception)
+        {
+            // log the error
+            Log.e("CreatePostActivity", "Error uploading image to Supabase", e)
+            return ""
         }
     }
+
+    // endregion
+
+    // region Image Picker Methods
+
+    // Function to open the camera and let the user take a photo
+    private fun pickImageFromCamera()
+    {
+        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        imageCaptureLauncher.launch(cameraIntent)  // Opens the camera to take an image
+    }
+
+    // Function to open the gallery and let the user pick an image
+    private fun pickImageFromGallery()
+    {
+        pickImageLauncher.launch("image/*")  // Opens the gallery to pick an image
+    }
+    // endregion
+
+    // region Image Activity Launchers
+
+    // Register a launcher for requesting CAMERA permission.
+    private val requestCameraPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted)
+            {
+                // The permission is granted, you can proceed to launch the camera.
+                pickImageFromCamera()
+            }
+            else
+            {
+                Toast.makeText(
+                    this,
+                    "Camera permission is required to take a photo.",
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
+
+    // Activity result launcher for capturing an image from the camera
+    private val imageCaptureLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK)
+            {
+                val photo = result.data?.extras?.get("data") as? Bitmap
+
+                photo?.let {
+                    ivProfilePicture.setImageBitmap(it) // Display the selected image
+
+                    // Convert the image bitmap to a ByteArray
+                    val byteArray = bitmapToByteArray(it)
+                    Log.d("Camera", "Byte array size: ${byteArray.size}")
+
+                    if (byteArray.isNotEmpty())
+                    {
+                        image = byteArray // Update the image variable
+                    }
+                    else
+                    {
+                        Toast.makeText(this, "Error processing image", Toast.LENGTH_SHORT).show()
+                        Log.e("CreateUserProfileActivity", "Image conversion failed")
+                    }
+                }
+            }
+        }
+
+    // Activity result launcher for selecting an image from the gallery
+    private val pickImageLauncher =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+
+            // If the user selects an image, update the ImageView
+            uri?.let {
+                ivProfilePicture.setImageURI(it)  // Display the selected image
+
+                // Convert the image URI to a Base64 string
+                val convertedImage = uriToByteArray(it)
+
+                if (convertedImage?.isNotEmpty() == true)
+                {
+                    image = convertedImage // Update the image variable
+                }
+                else
+                {
+                    Toast.makeText(this, "Error processing image", Toast.LENGTH_SHORT).show()
+                    Log.e("CreateUserProfileActivity", "Image conversion failed")
+                }
+            }
+        }
+    // endregion
+
+    // region Image Converters
+
+    // Function to convert image URI to ByteArray
+    private fun uriToByteArray(uri: Uri): ByteArray?
+    {
+        return try
+        {
+            contentResolver.openInputStream(uri)?.use { inputStream ->
+
+                ByteArrayOutputStream().use { outputStream ->
+
+                    // Copy the entire input stream data into the output stream
+                    inputStream.copyTo(outputStream)
+                    outputStream.toByteArray()
+                }
+            }
+        }
+        catch (e: Exception)
+        {
+            Log.e("CreateUserProfileActivity", "Error converting image URI to ByteArray", e)
+            ByteArray(0) // Return an empty byte array on error
+        }
+    }
+
+    private fun bitmapToByteArray(bitmap: Bitmap): ByteArray
+    {
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+        return stream.toByteArray()
+    }
+    // endregion
 
 }

--- a/app/src/main/java/com/fakebook/SocialMediaApp/DataModels/User.kt
+++ b/app/src/main/java/com/fakebook/SocialMediaApp/DataModels/User.kt
@@ -6,5 +6,5 @@ data class User(
     val username: String,
     val fullName: String,
     val bio: String,
-    val base64ProfilePicture: String
+    val profilePictureLink: String
 )


### PR DESCRIPTION
- Replaced Base64 encoding with Supabase Storage for storing user profile pictures.
- Updated `User` data model to use a `profilePictureLink` instead of `base64ProfilePicture`.
- Added Supabase client initialization with Postgrest and Storage.
- Added functionality to upload images to Supabase Storage and retrieve their public URLs.
- Replaced image selection from only gallery to now from gallery and camera.
- Added permission check for camera usage.
- Added Image processing with `bitmapToByteArray()` and `uriToByteArray()`.